### PR TITLE
Deprecate `parseMultipartFormData()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.1] - 2023-09-24
+
+### Deprecated
+-  Deprecated `parseMultipartFormData()` due to [ReDoS  issue](https://github.com/shgysk8zer0/node-http/issues/2)
+
+### Fixed
+- Fix `imports` in `package.json` to work with `@shgysk8zer0/http/module` as well as `@shgysk8zer0/http/module.js`
+
 ## [v1.0.0] - 2023-09-22
 
 Initial Release

--- a/form-data.js
+++ b/form-data.js
@@ -5,6 +5,8 @@ const PATTERN = /^(\r\n)?(?:Content-Disposition:\s?form-data;\s?name="(?<name>[^
 /**
  * Parse a multipart/form-data body and extract form fields and files.
  *
+ * @deprecated This function is potentially vulnerable to ReDoS attacks and is not necessary in node >= 20
+ * @see https://github.com/shgysk8zer0/node-http/issues/2
  * @param {string} body - The raw string of the multipart/form-data body.
  * @param {string} contentType - The Content-Type header specifying the boundary.
  * @returns {FormData} - A FormData object containing the parsed data.
@@ -12,6 +14,8 @@ const PATTERN = /^(\r\n)?(?:Content-Disposition:\s?form-data;\s?name="(?<name>[^
  * @throws {Error} - If the contentType is not valid for multipart/form-data.
  */
 export function parseMultipartFormData(body, contentType) {
+	console.warn('parseMultipartFormData() is deprecated and will be removed in version 2.0.0');
+
 	if (typeof body !== 'string') {
 		throw new TypeError('body must be a string.');
 	} else	if (typeof contentType !== 'string') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shgysk8zer0/http",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shgysk8zer0/http",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,14 @@
 {
   "name": "@shgysk8zer0/http",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A JavaScript library that provides various utilities for working with HTTP",
-  "keywords": ["http", "http-status", "http-error","form-data", "http-cookie", "file-object"],
+  "keywords": [
+    "http",
+    "http-status",
+    "http-error",
+    "http-cookie",
+    "node-http"
+  ],
   "type": "module",
   "main": "http.cjs",
   "module": "http.js",
@@ -11,6 +17,9 @@
     ".": {
       "import": "./http.js",
       "require": "./http.cjs"
+    },
+    "./*.js": {
+      "import": "./*"
     },
     "./*": {
       "import": "./*.js"


### PR DESCRIPTION
References #2

This function will no longer be necessary in node >= 20 but I don't
think can be fixed (at  least  not easily and isn't worth it). Will be
removed in an upcoming release, and used a `console.warn` when used.

Also update such that `import '@shgysk8zer0/http/module'` and
`import '@shgysk8zer0/http/module.js'` to both work.

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
